### PR TITLE
Update SDK, Java version, and Android package documentation

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -28,7 +28,7 @@ env:
   SCL_DEPENDENCY_TRACKER_SERVER_URL: ${{          secrets.SCL_DEPENDENCY_TRACKER_SERVER_URL          }}
   SCL_DEPENDENCY_TRACKER_SIGNING_PRIVATE_KEY: ${{ secrets.SCL_DEPENDENCY_TRACKER_SIGNING_PRIVATE_KEY }}
 
-  DOTNET_TARGET_WORKLOAD_VERSION: "8.0.402" # dont upgrade this lightheartedly   the workload snapshot implicitly defines which versions of Android/iOS/MacCatalyst SDKs are supported
+  DOTNET_TARGET_WORKLOAD_VERSION: "10.0.203" # dont upgrade this lightheartedly   the workload snapshot implicitly defines which versions of Android/iOS/MacCatalyst SDKs are supported
 
 
 on:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -71,14 +71,14 @@ jobs:
                              "${{env.SCL_GITHUB_ACCESS_TOKEN}}"                                                  \
                              "${{env.BUILD_REPOSITORY_FOLDERPATH}}/Artifacts"
 
-      # we need to manually install java11 because it is needed by the latest windows vm-images that run on
+      # we need to manually install java17 because it is needed by the latest windows vm-images that run on
       # msbuild version 17.8.3 that started rolling out around 20 Nov 2023 https://stackoverflow.com/a/77519085/863651
-      - name: '🛠 Set Up JDK 11'
-        uses: 'actions/setup-java@v2'
+      - name: '🛠 Set Up JDK 17'
+        uses: 'actions/setup-java@v4'
         with:
-          java-version: '11'
+          java-version: '17'
           architecture: 'x64'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: '🏗 📦 Build, Pack & Announce New Release (if appropriate)'
         shell: 'bash'

--- a/Laerdal.Dfu.Bindings.Android/Laerdal.Dfu.Bindings.Android.csproj
+++ b/Laerdal.Dfu.Bindings.Android/Laerdal.Dfu.Bindings.Android.csproj
@@ -3,7 +3,7 @@
         <Laerdal_Package_Name>Laerdal.Dfu.Bindings.Android</Laerdal_Package_Name>
         <Laerdal_Package_Tags>Ble;Tools;MAUI;Dfu;Bluetooth;Nordic;Semiconductor</Laerdal_Package_Tags>
         <Laerdal_Package_Copyright>Laerdal Medical, Francois Raminosona</Laerdal_Package_Copyright>
-        <Laerdal_Package_Description>Xamarin wrapper around Nordic.Dfu for Android.</Laerdal_Package_Description>
+        <Laerdal_Package_Description>.NET MAUI binding for Nordic DFU library on Android.</Laerdal_Package_Description>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Laerdal.Dfu.Bindings.Android/Laerdal.Dfu.Bindings.Android.csproj
+++ b/Laerdal.Dfu.Bindings.Android/Laerdal.Dfu.Bindings.Android.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net8.0-android</TargetFramework>
+        <TargetFramework>net10.0-android</TargetFramework>
 
         <IsBindingLibrary>true</IsBindingLibrary>
         <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
@@ -28,7 +28,7 @@
 
     <!-- ==================== TARGET PLATFORM VERSION ======================= -->
     <PropertyGroup>
-        <TargetPlatformVersion>34</TargetPlatformVersion>
+        <TargetPlatformVersion>36</TargetPlatformVersion>
         <TargetPlatformMinVersion>21.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
     </PropertyGroup>

--- a/Laerdal.Dfu.Bindings.Android/Laerdal.Dfu.Bindings.Android.csproj
+++ b/Laerdal.Dfu.Bindings.Android/Laerdal.Dfu.Bindings.Android.csproj
@@ -59,19 +59,10 @@
             Name="_DownloadAndroidNativeFiles"
             BeforeTargets="PrepareForBuild">
 
-        <!-- note that the vanilla aar build of version 2.4.2 was problematic for C# bindings https://github.com/NordicSemiconductor/Android-DFU-Library/pull/435 -->
-        <!-- so we resorted to generating a custom aar which solves the problems mentioned in the link and we hosted it on a different location                   -->
-        <DownloadFile Condition=" '$(Nordic_Package_Version)' != '2.4.2' and !Exists('Jars\dfu-$(Nordic_Package_Version).aar') "
+        <DownloadFile Condition=" !Exists('Jars\dfu-$(Nordic_Package_Version).aar') "
                       SourceUrl="https://repo1.maven.org/maven2/no/nordicsemi/android/dfu/$(Nordic_Package_Version)/dfu-$(Nordic_Package_Version).aar"
                       DestinationFolder="Jars"
                       DestinationFileName="dfu-$(Nordic_Package_Version).aar"/>
-
-        <!-- HACK remove this once we move past version 2.4.2 and https://github.com/NordicSemiconductor/Android-DFU-Library/pull/435 is merged -->
-        <DownloadFile Condition=" '$(Nordic_Package_Version)' == '2.4.2' and !Exists('Jars\dfu-$(Nordic_Package_Version).aar') "
-                      SourceUrl="https://github.com/Laerdal/Laerdal.Dfu.Bindings.Android/files/15408955/dfu-2.4.2.fixed_aar.zip"
-                      DestinationFolder="Jars"
-                      DestinationFileName="dfu-$(Nordic_Package_Version).aar"/>
-        <!-- END HACK -->
 
         <DownloadFile Condition=" !Exists('Jars\gson-$(Gson_Package_Version).jar') "
                       SourceUrl="https://repo1.maven.org/maven2/com/google/code/gson/gson/$(Gson_Package_Version)/gson-$(Gson_Package_Version).jar"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.0",
-    "rollForward": "latestFeature",
+    "version": "10.0.0",
+    "rollForward": "latestMinor",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
This pull request updates the Android bindings and build environment to support .NET 10 and newer Android platform versions. It also modernizes the CI workflow by upgrading Java and .NET versions, and removes legacy workarounds for older dependencies.

**Platform and Dependency Upgrades:**

* Updated the target framework in `Laerdal.Dfu.Bindings.Android.csproj` from `net8.0-android` to `net10.0-android`, and increased the Android `TargetPlatformVersion` from 34 to 36 to support the latest Android features. [[1]](diffhunk://#diff-e1ce1c0250aefe666c31a1dda612b0f4ab2e7b16b062132c5f688b71c7acc578L6-R10) [[2]](diffhunk://#diff-e1ce1c0250aefe666c31a1dda612b0f4ab2e7b16b062132c5f688b71c7acc578L31-R31)
* Updated the .NET SDK version in `global.json` from `8.0.0` to `10.0.0`, and changed the roll-forward policy to `latestMinor` for improved compatibility.
* Updated the `DOTNET_TARGET_WORKLOAD_VERSION` in the GitHub Actions workflow from `8.0.402` to `10.0.203` to match the new target framework.

**CI/CD Workflow Improvements:**

* Upgraded the GitHub Actions Java setup from JDK 11 to JDK 17, switched from `adopt` to `temurin` distribution, and updated the setup-java action from v2 to v4 for better support with recent Windows VM images.

**Dependency Download Logic Simplification:**

* Removed special-case logic for downloading a patched Nordic DFU 2.4.2 AAR, as the workaround is no longer needed. Now, the standard Maven repository is used for all versions.